### PR TITLE
Added unload method to iterate through all loaded plugin and assertio…

### DIFF
--- a/slz/slz_Assertions.js
+++ b/slz/slz_Assertions.js
@@ -255,6 +255,6 @@ class rmAssert {
 
 console.log('****Loading slz_Assertions to rmAssert class****')
 
-window.rmAssert = rmAssert
+// window.rmAssert = rmAssert
 
 

--- a/slz_testHarness.js
+++ b/slz_testHarness.js
@@ -115,6 +115,7 @@ TestRunner.runAllTests = function () {
         slz_Reporter.createTestReport()
         this.runTest(list[i].loadTestData())
     }
+
 }
 
 
@@ -448,6 +449,10 @@ class TestFileManager {
         console.log(error)
     }
 
+    static load(){
+        this.loadAssertionEngines()
+    }
+
     static loadAssertionEngines() {
         let assertionsLoaded = [];
         let assertions = [];
@@ -550,22 +555,6 @@ class TestFileManager {
         return true;
     }
 
-    static on_assertionsLoaded(){
-        console.log('ready to load plugins')
-        this.loadPlugins()
-    }
-
-    static on_testsLoaded(){
-        console.log('all yo shit loaded')
-        TestRunner.runAllTests()
-        slz_Reporter.printAllReports()
-    }
-
-    static on_pluginsLoaded(){
-        console.log('ready to load tests')
-        this.loadTests()
-    }
-
     static pluginsLoaded() {
         let list = this._pluginsLoaded;
         let length = list.length;
@@ -590,6 +579,22 @@ class TestFileManager {
         return true;
     }
 
+    static on_assertionsLoaded(){
+        console.log('ready to load plugins')
+        this.loadPlugins()
+    }
+
+    static on_testsLoaded(){
+        console.log('all yo shit loaded')
+        TestRunner.runAllTests()
+        slz_Reporter.printAllReports()
+        this.unload()
+    }
+
+    static on_pluginsLoaded(){
+        console.log('ready to load tests')
+        this.loadTests()
+    }
     
 
     static loadFile(filePath, success) {
@@ -618,5 +623,15 @@ class TestFileManager {
             TestFileManager.onErrorCb(e);
         }
     }
+
+    static unload(){
+        let list = this.plugins.concat(this.assertions)
+        let length = list.length;
+
+        for(let i = 0; i < length; i++){
+            window[list[i]] = undefined
+            delete window[list[i]]
+        }
+    }   
 
 }


### PR DESCRIPTION
…n engine names, both set them to undefined on window, and then delete the property. Added unload invoke after printing reports, during the on_testLoaded callback. This should only kickoff if at least one test was loaded. may be necessary to investigate auto unloading if plugins or engines were loaded, but tests werent