### PR TITLE
BRANCH NAME diversion. Original task canceled. Added requiresPlugin f…

### DIFF
--- a/slz/slz_Assertions.js
+++ b/slz/slz_Assertions.js
@@ -200,6 +200,6 @@ class rmAssert {
 
 console.log('****Loading slz_Assertions to rmAssert class****')
 
-// window.rmAssert = rmAssert
+window.rmAssert = rmAssert
 
 

--- a/slz/test/test1.js
+++ b/slz/test/test1.js
@@ -1,4 +1,5 @@
 slz_Test("Test A", () => {
+    requiresPlugin('slz_sandbox')
     //can scope varibles to entire test instace
     let testLevelVar = 'Running Before All'
     return [


### PR DESCRIPTION
…unction, which can be included in test. If that plugin is not available, the program will throw an error before it runs the test. Next need to do the same for engines, and then instead of stopping the programming, catch the error and prevent tests from running