### PR TITLE
Fixed a few errors where missing dependencies weren't preventing the …

### DIFF
--- a/slz/components/slz_sandbox.js
+++ b/slz/components/slz_sandbox.js
@@ -71,8 +71,7 @@ class slz_Spy {
 
             this.callCount++
             this.calledArgs.push(args)
-            console.log(this)
-            console.log(f)
+
             return f.apply(obj, args)
         }
 
@@ -98,7 +97,6 @@ class slz_Spy {
         let length = list.length;
         let count = 0;
 
-        console.log(args)
         args.sort((a, b) => a.toString().localeCompare(b.toString()))
         for (let i = 0; i < length; i++) {
             currentArgList = list[i].clone()
@@ -307,7 +305,6 @@ class Mock_Function {
         let length = list.length;
 
         for (let i = 0; i < length; i++) {
-            console.log(list[i], args)
             if (standardPlayer.sp_Core.areEquivalent(list[i], args)) {
                 return [this.cb[i], i]
             }

--- a/slz/components/slz_tellon.js
+++ b/slz/components/slz_tellon.js
@@ -36,7 +36,6 @@ class CaseReport extends TellonReport {
     actual;
 
     constructor(data) { //data = [pass, expected, actual]
-        console.log(data)
         super("", data)
         this.pass = data[0];
         this.expected = data[1];
@@ -98,7 +97,6 @@ class TestReport extends TellonReport {
     }
 
     addReport(heading, data) {
-        console.log('Whie creating Scenario report, giving it : ' + heading)
         let report = new ScenarioReport(heading, data)
 
         this.reports.push(report)
@@ -159,6 +157,10 @@ class TellonReporter extends HarnessReporter {
 
     constructor() {
         throw new Error('This is a static class')
+    }
+
+    static print(){
+        this.printAllReports()
     }
 
     static createReport(heading, args) {

--- a/slz/languages/slz_Sinot.js
+++ b/slz/languages/slz_Sinot.js
@@ -45,7 +45,7 @@ function sinot_Test(title, getTestData) {
         loadTestData: () => { return getTestData().filter(a => typeof a == 'object') }
     }
 
-    TestRunner.tests.push(obj)
+    TestRunner.addTest(obj)
 }
 
 function resetHooks() {
@@ -109,7 +109,7 @@ function runTest(list) { //list is test file using Sinot.js
         let scenario = list[i]
         let testCases = scenario.getScenarioData()
         let length2 = testCases.length;
-        console.log(scenario.title)
+
         reporter.createReport(scenario.title)
         sinot.model.scenarioHeading = scenario.title //<-- Don't think this was even used in POC
         sinot.model.beforeEachScenario()


### PR DESCRIPTION
…program from continuing. Added unloading process, fixed error where continuous TestRunner.run() calls were not possible, because the HarnessFileManager was never emptying the globalNames after removing the loaded manifest objects, so on a subsequent run, dependecies were being told they were already loaded