### PR TITLE
added Assert tests

### DIFF
--- a/slz/tests/test1.js
+++ b/slz/tests/test1.js
@@ -8,35 +8,104 @@ sinot.createTest("Test A", () => {
     return [
         sinot.scenario("Testing Asserts", () => {
             return [
-                
-                sinot.testCase("Check assertFalse is true", () => {
-                    rmAssert.assertFalse(false);
-                }),   
-                sinot.testCase("Check assertFalse is false", () => {
-                    rmAssert.assertFalse(true);
-                }),             
+
+                //assertTrue             
                 sinot.testCase("Check assertTrue is true", () => {
                     rmAssert.assertTrue(true)
                 }),             
                 sinot.testCase("Check assertTrue is false", () => {
                     rmAssert.assertTrue(false);
+                }),     
+                
+                //assertFalse       
+                sinot.testCase("Check assertFalse is true", () => {
+                    rmAssert.assertFalse(false);
+                }),   
+                sinot.testCase("Check assertFalse is false", () => {
+                    rmAssert.assertFalse(true);
+                }),
+
+                //assertEquals
+                sinot.testCase("Check assertEquals is true", () => {
+                    let expected = 10;
+                    let actual = 10;
+                    rmAssert.assertEquals(expected, actual)
                 }),
                 sinot.testCase("Check assertEquals is false", () => {
                     let expected = 10;
                     let actual = 9;
                     rmAssert.assertEquals(expected, actual)
                 }),
-                sinot.testCase("Should be an instance of Scene_Battle", () => {
-                    let expected = SceneManager._scene;
-                    let actual = Scene_Battle
-                    rmAssert.assertInstance(expected, actual)
+
+                //assertNotEquals
+                sinot.testCase("Check assertNotEquals is true", () => {
+                    let expected = 10;
+                    let actual = 9;
+                    rmAssert.assertNotEquals(expected, actual)
                 }),
+                sinot.testCase("Check assertNotEquals is false", () => {
+                    let expected = 10;
+                    let actual = 10;
+                    rmAssert.assertNotEquals(expected, actual)
+                }),
+
+                //assertNull
+                sinot.testCase("Check assertNull is true", () => {
+                    rmAssert.assertNull(null);
+                }),
+                sinot.testCase("Check assertNull is false", () => {
+                    rmAssert.assertNull({objName:"name"});
+                }),
+
+                //assertNotNull
                 sinot.testCase("Check assertNotNull is true", () => {
                     rmAssert.assertNotNull({objName:"name"});
                 }),
                 sinot.testCase("Check assertNotNull is false", () => {
                     rmAssert.assertNotNull(null);
                 }),
+
+                //assertString
+                sinot.testCase("Check assertString is true", () => {
+                    rmAssert.assertString("It's a string");
+                }),
+                sinot.testCase("Check assertString is false", () => {
+                    rmAssert.assertString(5);
+                }),
+
+                //assertNumber
+                sinot.testCase("Check assertNumber is true", () => {
+                    rmAssert.assertNumber(5);
+                }),
+                sinot.testCase("Check assertNumber is false", () => {
+                    rmAssert.assertNumber("It's a string");
+                }),
+
+                //assertObject
+                sinot.testCase("Check assertObject is true", () => {
+                    rmAssert.assertObject({name:"objName"});
+                }),
+                sinot.testCase("Check assertObject is false", () => {
+                    rmAssert.assertObject("It's a string");
+                }),
+
+                //assertBoolean
+                sinot.testCase("Check assertBoolean is true", () => {
+                    rmAssert.assertBoolean(false);
+                }),
+                sinot.testCase("Check assertBoolean is false", () => {
+                    rmAssert.assertBoolean("It's a string");
+                }),
+
+                //assertFunction
+                sinot.testCase("Check assertFunction is true", () => {
+                    rmAssert.assertFunction(() => {console.log("it's a function")});
+                }),
+                sinot.testCase("Check assertFunction is false", () => {
+                    rmAssert.assertFunction({name:"objName"});
+                }),
+
+                //assertInstance
                 sinot.testCase("Check assertInstance is true", () => {
                     let sm = SceneManager._scene;
                     rmAssert.assertInstance(sm._messageWindow, Window_Base);

--- a/slz_testHarness.js
+++ b/slz_testHarness.js
@@ -122,7 +122,9 @@ slz_Harness.addTest = function(data) {
     }    
 }
 
-slz_Harness.execute = function () {   //<-- should/could accept test running params
+slz_Harness.execute = function (testIndex) {   //<-- should/could accept test running params
+    console.log(testIndex)
+    let tests = typeof testIndex == 'undefined' ? this._loadedTests : [this._loadedTests[testIndex]]
     if (this._hasError) {
        console.log(this.errorMessage()); 
        return;


### PR DESCRIPTION
For every assert case there is a positive and negative test case. To make sure all asserts are working as they should, running the tests should give alternating pass/fail results. If any other pass/fail order than pass - fail - pass - fail etc. occurs, that means an assert method or the test written is broken.